### PR TITLE
Feat: 주가 API 호출 및 DB에 데이터 저장

### DIFF
--- a/src/app/[locale]/(headerLayout)/report/[id]/page.tsx
+++ b/src/app/[locale]/(headerLayout)/report/[id]/page.tsx
@@ -1,31 +1,11 @@
 import ReportContainer from "@/containers/report/ReportContainer";
 import {
-  basicApi,
   calcPriceApi,
   integrationApi,
   realtimeApi,
-} from "@/app/api/report/stockApi";
-
-export type TCodes = {
-  [key: string]: string; // index signature
-  aapl: string;
-  tsla: string;
-  amzn: string;
-  msft: string;
-  googl: string;
-  u: string;
-  nvda: string;
-};
-
-export const codes: TCodes = {
-  aapl: "AAPL.O",
-  tsla: "TSLA.O",
-  amzn: "AMZN.O",
-  msft: "MSFT.O",
-  googl: "GOOGL.O",
-  u: "U",
-  nvda: "NVDA.O",
-};
+} from "@/services/report/stockApi";
+import stockPriceApi from "@/services/report/stockPriceApi";
+import { stockPriceUpdateApi } from "@/services/report/stockPriceUpdateApi";
 
 type TParams = {
   params: {
@@ -37,24 +17,39 @@ type TParams = {
 export default async function Page({ params }: TParams) {
   const { id } = params;
 
-  const realtimeData = await realtimeApi(id);
-  const integrationData = await integrationApi(id);
-  const calcPriceData = await calcPriceApi();
-  const basicData = await basicApi(id);
+  const {
+    reutersCode,
+    stockName,
+    symbolCode,
+    closePrice,
+    compareToPreviousClosePrice,
+    fluctuationsRatio,
+    stockExchangeType,
+  }: any = await realtimeApi(id);
+
+  const corporateOverview = await integrationApi(id);
+
+  const calcPrice = await calcPriceApi();
+
+  const stockPriceData = await stockPriceApi({
+    code: reutersCode,
+    stockExchangeType,
+  });
+
+  await stockPriceUpdateApi(stockPriceData, id.toUpperCase());
 
   return (
     <>
       <ReportContainer
-        stockName={realtimeData.stockName}
-        symbolCode={realtimeData.symbolCode}
-        closePrice={realtimeData.closePrice}
-        compareToPreviousClosePrice={realtimeData.compareToPreviousClosePrice}
-        fluctuationsRatio={realtimeData.fluctuationsRatio}
-        corporateOverview={integrationData}
-        calcPrice={calcPriceData}
-        stockExchangeName={basicData}
-        id={id}
-        code={codes[id]}
+        reutersCode={reutersCode}
+        stockName={stockName}
+        symbolCode={symbolCode}
+        closePrice={closePrice}
+        compareToPreviousClosePrice={compareToPreviousClosePrice}
+        fluctuationsRatio={fluctuationsRatio}
+        stockExchangeType={stockExchangeType}
+        corporateOverview={corporateOverview}
+        calcPrice={calcPrice}
       />
     </>
   );

--- a/src/app/api/stocks/route.ts
+++ b/src/app/api/stocks/route.ts
@@ -1,5 +1,5 @@
 import { firestore } from "@/firebase/firebasedb";
-import { collection, getDocs } from "firebase/firestore";
+import { collection, doc, getDocs, updateDoc } from "firebase/firestore";
 
 // stocks 컬렉션의 모든 doc을 조회하여 배열로 반환
 export async function GET(request: Request) {
@@ -7,4 +7,29 @@ export async function GET(request: Request) {
   const data = querySnap.docs.map((doc) => doc.data());
 
   return Response.json(data);
+}
+
+// stocks 컬렉션의 해당 doc의 stockPrice 필드에 데이터 저장
+export async function updateStockPrice(request: Request) {
+  try {
+    const { stockPriceData, id } = await request.json();
+
+    if (!stockPriceData || !id) {
+      return new Response(JSON.stringify({ error: "Missing parameters" }), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const docRef = doc(firestore, "stocks", id);
+    await updateDoc(docRef, { stockPrice: stockPriceData });
+
+    return new Response(
+      JSON.stringify({ message: "Stock price updated successfully" }),
+      { headers: { "Content-Type": "application/json" } },
+    );
+  } catch (error: any) {
+    return new Response(JSON.stringify({ error: `Error: ${error.message}` }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
 }

--- a/src/containers/report/AIAnalyst.tsx
+++ b/src/containers/report/AIAnalyst.tsx
@@ -9,26 +9,28 @@ import {
 } from "@/icons";
 
 type TAiAnalystProps = {
+  reutersCode: string;
   stockName: string;
   symbolCode: string;
   closePrice: string;
   compareToPreviousClosePrice: string;
   fluctuationsRatio: string;
-  id: string;
+  // id: string;
 };
 
 export default function AiAnalyst(props: TAiAnalystProps) {
   const {
+    reutersCode,
     stockName,
     symbolCode,
     closePrice,
     compareToPreviousClosePrice,
     fluctuationsRatio,
-    id,
+    // id,
   } = props;
 
-  const getStockLogo = (id: string) => {
-    switch (id) {
+  const getStockLogo = (reutersCode: string) => {
+    switch (reutersCode) {
       case "aapl":
         return <IconApple width={33} height={33} />;
       case "tsla":
@@ -71,7 +73,7 @@ export default function AiAnalyst(props: TAiAnalystProps) {
       </h3>
       <div className="flex items-center mb-4">
         <div className="flex flex-row">
-          {getStockLogo(id)}
+          {getStockLogo(reutersCode)}
           <div className="flex items-center ml-2">
             {/* 주식명 */}
             <p className="text-lg text-grayscale-900 font-medium mr-2">

--- a/src/containers/report/News.tsx
+++ b/src/containers/report/News.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import { useState } from "react";
 

--- a/src/containers/report/ReportContainer.tsx
+++ b/src/containers/report/ReportContainer.tsx
@@ -1,38 +1,26 @@
-"use client";
-
-import { useState } from "react";
+import StockHeader from "./StockHeader";
 import StockPrice from "./StockPrice";
 import StockChart from "./StockChart";
 import AIStockList from "./AIStockList";
 import AiAnalyst from "./AIAnalyst";
 import News from "./News";
-import {
-  IconApple,
-  IconTsla,
-  IconAmazon,
-  IconMs,
-  IconGoogle,
-  IconUnity,
-  IconNvidia,
-} from "@/icons";
 
 type TReportContainer = {
+  reutersCode: string;
   stockName: string;
   symbolCode: string;
   closePrice: string;
   compareToPreviousClosePrice: string;
   fluctuationsRatio: string;
-
+  stockExchangeType: string;
   corporateOverview: string;
   calcPrice: string;
-  stockExchangeName: string;
-  id: string;
-  code: string;
 };
 
 export default function ReportContainer(props: TReportContainer) {
   // ...rest
   const {
+    reutersCode,
     stockName,
     symbolCode,
     closePrice,
@@ -40,35 +28,8 @@ export default function ReportContainer(props: TReportContainer) {
     fluctuationsRatio,
     corporateOverview,
     calcPrice,
-    stockExchangeName,
-    id,
-    code,
+    stockExchangeType,
   } = props;
-
-  const [isFavorite, setIsFavorite] = useState<boolean>(false);
-
-  const handleButtonClick = (): void => {
-    setIsFavorite(!isFavorite);
-  };
-
-  const getStockLogo = (id: string) => {
-    switch (id) {
-      case "aapl":
-        return <IconApple width={64} height={64} />;
-      case "tsla":
-        return <IconTsla width={64} height={64} />;
-      case "amzn":
-        return <IconAmazon width={64} height={64} />;
-      case "msft":
-        return <IconMs width={64} height={64} />;
-      case "googl":
-        return <IconGoogle width={64} height={64} />;
-      case "u":
-        return <IconUnity width={64} height={64} />;
-      case "nvda":
-        return <IconNvidia width={64} height={64} />;
-    }
-  };
 
   return (
     <>
@@ -77,27 +38,11 @@ export default function ReportContainer(props: TReportContainer) {
           {/* top-box */}
           <div className="">
             {/* 헤더 섹션 */}
-            <div className="flex justify-between text-navy-900 mb-6">
-              <div className="flex flex-row items-center">
-                {getStockLogo(id)}
-                <h4 className="font-bold ml-3 flex items-center gap-2">
-                  {stockName}
-                  <span className="text-xl font-medium before:content-['_•_']">
-                    {symbolCode}
-                  </span>
-                </h4>
-              </div>
-              <button
-                className={`w-[180px] h-[56px] rounded-lg text-base font-medium ${
-                  isFavorite
-                    ? "border border-navy-900 text-navy-900"
-                    : "bg-navy-900 text-white"
-                }`}
-                onClick={handleButtonClick}
-              >
-                {isFavorite ? "관심종목 해제" : "관심종목 추가"}
-              </button>
-            </div>
+            <StockHeader
+              reutersCode={reutersCode}
+              stockName={stockName}
+              symbolCode={symbolCode}
+            />
             <div>
               <div className="flex flex-row w-[1200px] h-[256px] gap-[20px] mb-6">
                 <StockPrice
@@ -108,17 +53,20 @@ export default function ReportContainer(props: TReportContainer) {
                   corporateOverview={corporateOverview}
                   calcPrice={calcPrice}
                 />
-                <StockChart code={code} stockExchangeName={stockExchangeName} />
+                <StockChart
+                  reutersCode={reutersCode}
+                  stockExchangeType={stockExchangeType}
+                />
               </div>
               <div className="flex flex-row w-[1200px] h-[297px] gap-[20px] mb-10">
                 <AIStockList />
                 <AiAnalyst
+                  reutersCode={reutersCode}
                   stockName={stockName}
                   symbolCode={symbolCode}
                   closePrice={closePrice}
                   compareToPreviousClosePrice={compareToPreviousClosePrice}
                   fluctuationsRatio={fluctuationsRatio}
-                  id={id}
                 />
               </div>
             </div>

--- a/src/containers/report/StockChart.tsx
+++ b/src/containers/report/StockChart.tsx
@@ -4,13 +4,12 @@ import { useState } from "react";
 import AreaChart from "@/components/Chart/AreaChart";
 
 type TStockChartProps = {
-  code: string;
-  stockExchangeName: string;
+  reutersCode: string;
+  stockExchangeType: string;
 };
 
 export default function StockChart(props: TStockChartProps) {
-  const { code, stockExchangeName } = props;
-  const stockExchangeType = stockExchangeName;
+  const { reutersCode, stockExchangeType } = props;
 
   // 기간 버튼 state
   const [selected, setSelected] = useState<string>("1일");
@@ -28,22 +27,21 @@ export default function StockChart(props: TStockChartProps) {
 
         {/* 기간 선택 버튼들 */}
         <div className="flex flex-col gap-2 text-sm font-medium">
-          {buttons.map((button, index) => (
+          {buttons.map((item, index) => (
             <button
               key={index}
               // 버튼 클릭 시 선택된 버튼 상태를 업데이트
               onClick={() => {
-                setSelected(button);
-                // stockPriceApi({ code, button, stockExchangeType });
+                setSelected(item);
               }}
               // 선택된 버튼과 선택되지 않은 버튼의 스타일 적용
               className={
-                selected === button
+                selected === item
                   ? "w-16 h-8 bg-navy-50 rounded-lg text-navy-900"
                   : "w-16 h-8 bg-white rounded-lg text-grayscale-400"
               }
             >
-              {button /* 차트의 기간 옵션 */}
+              {item /* 차트의 기간 옵션 */}
             </button>
           ))}
         </div>

--- a/src/containers/report/StockHeader.tsx
+++ b/src/containers/report/StockHeader.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import {
+  IconApple,
+  IconTsla,
+  IconAmazon,
+  IconMs,
+  IconGoogle,
+  IconUnity,
+  IconNvidia,
+} from "@/icons";
+
+type TStockHeaderProps = {
+  reutersCode: string;
+  stockName: string;
+  symbolCode: string;
+};
+
+export default function StockHeader(props: TStockHeaderProps) {
+  const { reutersCode, stockName, symbolCode } = props;
+
+  const [isFavorite, setIsFavorite] = useState<boolean>(false);
+
+  const handleButtonClick = (): void => {
+    setIsFavorite(!isFavorite);
+  };
+
+  const getStockLogo = (reutersCode: string) => {
+    switch (reutersCode) {
+      case "AAPL.O":
+        return <IconApple width={64} height={64} />;
+      case "TSLA.O":
+        return <IconTsla width={64} height={64} />;
+      case "AMZN.O":
+        return <IconAmazon width={64} height={64} />;
+      case "MSFT.O":
+        return <IconMs width={64} height={64} />;
+      case "GOOGL.O":
+        return <IconGoogle width={64} height={64} />;
+      case "U":
+        return <IconUnity width={64} height={64} />;
+      case "NVDA.O":
+        return <IconNvidia width={64} height={64} />;
+    }
+  };
+
+  return (
+    <div className="flex justify-between text-navy-900 mb-6">
+      <div className="flex flex-row items-center">
+        {getStockLogo(reutersCode)}
+        <h4 className="font-bold ml-3 flex items-center gap-2">
+          {stockName}
+          <span className="text-xl font-medium before:content-['_•_']">
+            {symbolCode}
+          </span>
+        </h4>
+      </div>
+      <button
+        className={`w-[180px] h-[56px] rounded-lg text-base font-medium ${
+          isFavorite
+            ? "border border-navy-900 text-navy-900"
+            : "bg-navy-900 text-white"
+        }`}
+        onClick={handleButtonClick}
+      >
+        {isFavorite ? "관심종목 해제" : "관심종목 추가"}
+      </button>
+    </div>
+  );
+}

--- a/src/services/report/stockApi.ts
+++ b/src/services/report/stockApi.ts
@@ -1,6 +1,18 @@
-import { codes } from "@/app/[locale]/(headerLayout)/report/[id]/page";
+export type TCodes = {
+  [key: string]: string; // index signature
+};
 
-// Real-time(실시간) 기반 데이터
+export const codes: TCodes = {
+  aapl: "AAPL.O",
+  tsla: "TSLA.O",
+  amzn: "AMZN.O",
+  msft: "MSFT.O",
+  googl: "GOOGL.O",
+  u: "U",
+  nvda: "NVDA.O",
+};
+
+// 실시간 기반 데이터
 export async function realtimeApi(code: string) {
   try {
     const response = await fetch(
@@ -12,7 +24,25 @@ export async function realtimeApi(code: string) {
     }
 
     const data = await response.json();
-    return data.datas[0];
+    const {
+      reutersCode,
+      stockName,
+      symbolCode,
+      closePrice,
+      compareToPreviousClosePrice,
+      fluctuationsRatio,
+      stockExchangeType,
+    } = data.datas[0];
+
+    return {
+      reutersCode,
+      stockName,
+      symbolCode,
+      closePrice,
+      compareToPreviousClosePrice,
+      fluctuationsRatio,
+      stockExchangeType: stockExchangeType.name,
+    };
   } catch (error) {
     console.error("error:", error);
   }
@@ -31,24 +61,6 @@ export async function integrationApi(code: string) {
 
     const data = await response.json();
     return data.corporateOverview;
-  } catch (error) {
-    console.error("error:", error);
-  }
-}
-
-// 기업 정보 및 종목 정보 (차트 이미지 포함)
-export async function basicApi(code: string) {
-  try {
-    const response = await fetch(
-      `https://api.stock.naver.com/stock/${codes[code]}/basic`,
-    );
-
-    if (!response.ok) {
-      throw new Error(response.statusText);
-    }
-
-    const data = await response.json();
-    return data.stockExchangeName;
   } catch (error) {
     console.error("error:", error);
   }

--- a/src/services/report/stockPriceApi.ts
+++ b/src/services/report/stockPriceApi.ts
@@ -1,0 +1,40 @@
+type TStockPriceApiProps = {
+  code: string;
+  stockExchangeType: string;
+};
+
+export default async function stockPriceApi(props: TStockPriceApiProps) {
+  const { code, stockExchangeType } = props;
+
+  const period = [
+    "day",
+    "month&range=3",
+    "month&range=12",
+    "year&range=3",
+    "year&range=10",
+  ];
+
+  try {
+    const fetchDatas = period.map(async (periodType) => {
+      const response = await fetch(
+        `https://api.stock.naver.com/chart/foreign/item/${code}?periodType=${periodType}&stockExchangeType=${stockExchangeType}`,
+      );
+
+      if (!response.ok) {
+        throw new Error(response.statusText);
+      }
+
+      return await response.json();
+    });
+
+    const data = await Promise.all(fetchDatas);
+
+    const stockPrice = data.map((item, index) => {
+      return { periodType: period[index], priceInfo: item.priceInfos };
+    });
+
+    return stockPrice;
+  } catch (error) {
+    console.error("error: ", error);
+  }
+}

--- a/src/services/report/stockPriceUpdateApi.ts
+++ b/src/services/report/stockPriceUpdateApi.ts
@@ -1,0 +1,22 @@
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+
+export async function stockPriceUpdateApi(stockPriceData: any, id: string) {
+  try {
+    const response = await fetch(`${BASE_URL}/api/stocks`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ stockPriceData, id }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.error || "failed");
+    }
+
+    const stockInfo = await response.json();
+    return stockInfo;
+  } catch (error: any) {
+    console.error("error: ", error);
+    throw error;
+  }
+}

--- a/src/types/stockType.ts
+++ b/src/types/stockType.ts
@@ -1,9 +1,12 @@
 export type TStockType = {
+  reutersCode: string;
   stockName: string;
   symbolCode: string;
   closePrice: string; //종가
   compareToPreviousClosePrice: string; //이전 종가와 비교
   fluctuationsRatio: string; //변동률
+  stockExchangeType: string;
+  // stockPrice: ;
 };
 
 export type TSearchCountType = {


### PR DESCRIPTION
## 📑 PR 요약
주가 API 호출 및 DB에 데이터 저장

## 🛠️ 작업 내용
- 주가 API 호출
- api/stocks/route.ts에 update 추가
- DB에 데이터 저장
- stockApi.ts services 폴더로 이동
- 코드 수정